### PR TITLE
Update custom-checkbox.md

### DIFF
--- a/snippets/custom-checkbox.md
+++ b/snippets/custom-checkbox.md
@@ -30,7 +30,7 @@ Creates a styled checkbox with animation on state change.
   <label class="checkbox" for="apples">
     <span>
       <svg width="12px" height="10px">
-        <use xlink:href="#check"></use>
+        <use href="#check"></use>
       </svg>
     </span>
     <span>Apples</span>
@@ -39,7 +39,7 @@ Creates a styled checkbox with animation on state change.
   <label class="checkbox" for="oranges">
     <span>
       <svg width="12px" height="10px">
-        <use xlink:href="#check"></use>
+        <use href="#check"></use>
       </svg>
     </span>
     <span>Oranges</span>


### PR DESCRIPTION
Replacing xlink:href to href.
According to MDN Web Docs, xlink:href is not recommended, and SVG 2 have removed the need for the xlink namespace, we can now use href for SVG.
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href#browser_compatibility